### PR TITLE
Change packages require to accept Emacs v29

### DIFF
--- a/dd-taskrunner-javascript.el
+++ b/dd-taskrunner-javascript.el
@@ -1,7 +1,7 @@
 ;;; dd-taskrunner-javascript.el --- Consult-based JS task runner -*- lexical-binding: t; -*-
 
 ;; Author: Diogo Doreto
-;; Package-Requires: ((emacs "30.1") (consult "2.5"))
+;; Package-Requires: ((emacs "29.4") (consult "2.5"))
 ;; Keywords: javascript, task-runner, npm, bun, yarn, pnpm
 ;; URL: https://github.com/DiogoDoreto/dd-taskrunner-javascript.el
 


### PR DESCRIPTION
As an [emacs-mac](https://github.com/railwaycat/homebrew-emacsmacport) user, I would like to use the task runner under emacs v29, the latest stable version released by emacs-mac, while v30.1 is an experimental version.
Since Emacs v30.1 is not a requirement to have the task runner working, and works well on v29 too, I am opening this PR to propose this change.

